### PR TITLE
Fix iOS - UnsafePointer fatal crash on Xcode 14 simulator

### DIFF
--- a/ios/Core/OTP.swift
+++ b/ios/Core/OTP.swift
@@ -118,14 +118,15 @@ public final class OTP : NSObject, KeychainStorable {
 
         // Unparse UInt32
         let off = Int(buf[buf.count - 1]) & 0x0f;
-        let msk = UnsafePointer<UInt8>(buf).advanced(by: off).withMemoryRebound(to: UInt32.self, capacity: size/4) {
-            $0[0].bigEndian & 0x7fffffff
+        let bin_code = Array(buf[off...off + 3])
+        var msk = bin_code.withUnsafeBytes {
+            $0.load(as: UInt32.self).bigEndian
         }
+        msk &= 0x7fffffff
 
         // Create digits divisor
         var div: UInt32 = 1
         for _ in 0..<digits { div *= 10 }
-
         return String(format: String(format: "%%0%hhulu", digits), msk % div)
     }
 }


### PR DESCRIPTION
Fixes  #14 :
A fatal crash on the Xcode 14 iOS simulator when generating a token pair.

The fix is based on this [commit](https://github.com/freeotp/freeotp-ios/commit/990735a141ca8f99f338a3d52599b268a9525e45).